### PR TITLE
Update model to align with handler requirements

### DIFF
--- a/mapclientplugins/meshprojectionstep/model/meshprojection.py
+++ b/mapclientplugins/meshprojectionstep/model/meshprojection.py
@@ -79,9 +79,13 @@ class MeshProjectionModel(object):
         rot_mx = axis_angle_to_rotation_matrix(cross(plane_normal, xy_normal), theta)
 
         rotation_point = self._plane.getRotationPoint()
-        rotate_nodes(self._projected_region, rot_mx, rotation_point, node_coordinate_field_name, datapoint_coordinate_field_name)
         delta = [-component for component in rotation_point]
-        translate_nodes(self._projected_region, delta, node_coordinate_field_name, datapoint_coordinate_field_name)
+        if datapoint_coordinate_field_name:
+            rotate_nodes(self._projected_region, rot_mx, rotation_point, node_coordinate_field_name, datapoint_coordinate_field_name)
+            translate_nodes(self._projected_region, delta, node_coordinate_field_name, datapoint_coordinate_field_name)
+        else:
+            rotate_nodes(self._projected_region, rot_mx, rotation_point, node_coordinate_field_name)
+            translate_nodes(self._projected_region, delta, node_coordinate_field_name)
 
         self._projected_region.writeFile(location)
 
@@ -154,7 +158,10 @@ class MeshProjectionModel(object):
         self.reset_projection()
         point_on_plane = self._plane.getRotationPoint()
         plane_normal = self._plane.getNormal()
-        project_nodes(self._projected_region, point_on_plane, plane_normal, node_coordinate_field_name, datapoint_coordinate_field_name)
+        if datapoint_coordinate_field_name:
+            project_nodes(self._projected_region, point_on_plane, plane_normal, node_coordinate_field_name, datapoint_coordinate_field_name)
+        else:
+            project_nodes(self._projected_region, point_on_plane, plane_normal, node_coordinate_field_name)
 
     def reset_projection(self):
         projection_field_module = self._projected_region.getFieldmodule()

--- a/mapclientplugins/meshprojectionstep/scene/meshprojection.py
+++ b/mapclientplugins/meshprojectionstep/scene/meshprojection.py
@@ -212,7 +212,7 @@ class MeshProjectionScene(object):
             self._projected_marker_graphics.setVisibilityFlag(state != 0)
 
     def create_projection_plane(self):
-        region = self._model.get_projection_plane_region()
+        region = self._model.get_plane_region()
         self._surface_graphics = _create_surface_graphics(region)
         self._surface_graphics.setMaterial(self._surface_material)
 

--- a/mapclientplugins/meshprojectionstep/scene/meshprojection.py
+++ b/mapclientplugins/meshprojectionstep/scene/meshprojection.py
@@ -220,7 +220,6 @@ class MeshProjectionScene(object):
         region = self._model.get_projected_region()
         fm = region.getFieldmodule()
         mesh_coordinates = fm.findFieldByName(mesh_coordinate_field_name)
-        marker_coordinates = fm.findFieldByName(marker_coordinate_field_name)
         scene = region.getScene()
         mm = scene.getMaterialmodule()
         green = mm.findMaterialByName('green')
@@ -234,5 +233,7 @@ class MeshProjectionScene(object):
             self._projected_mesh_graphics.setCoordinateField(mesh_coordinates)
             self._projected_mesh_graphics.setMaterial(blue)
 
-            self._projected_marker_graphics = self.create_point_graphics(scene, marker_coordinates, None, magenta,
-                                                                         Field.DOMAIN_TYPE_DATAPOINTS)
+            if marker_coordinate_field_name:
+                marker_coordinates = fm.findFieldByName(marker_coordinate_field_name)
+                self._projected_marker_graphics = self.create_point_graphics(scene, marker_coordinates, None, magenta,
+                                                                             Field.DOMAIN_TYPE_DATAPOINTS)

--- a/mapclientplugins/meshprojectionstep/view/meshprojection.py
+++ b/mapclientplugins/meshprojectionstep/view/meshprojection.py
@@ -162,7 +162,9 @@ class MeshProjectionWidget(QtWidgets.QWidget):
         self._scene.update_mesh_coordinates(self._ui.comboBoxNodeCoordinateField.currentData())
 
     def _update_datapoint_coordinates_field(self):
-        self._scene.update_datapoint_coordinates(self._ui.comboBoxDatapointCoordinateField.currentData())
+        datapoint_coordinates = self._ui.comboBoxDatapointCoordinateField.currentData()
+        if datapoint_coordinates:
+            self._scene.update_datapoint_coordinates(datapoint_coordinates)
 
     def _settings_file(self):
         return os.path.join(self._location, 'settings.json')
@@ -172,7 +174,8 @@ class MeshProjectionWidget(QtWidgets.QWidget):
             os.makedirs(self._location)
 
         node_coordinate_field_name = self._ui.comboBoxNodeCoordinateField.currentData().getName()
-        datapoint_coordinate_field_name = self._ui.comboBoxDatapointCoordinateField.currentData().getName()
+        datapoint_field = self._ui.comboBoxDatapointCoordinateField.currentData()
+        datapoint_coordinate_field_name = datapoint_field.getName() if datapoint_field else None
         self._model.write_projected_mesh(self.get_output_file(), node_coordinate_field_name, datapoint_coordinate_field_name)
 
     def _update_label_text(self):
@@ -208,7 +211,8 @@ class MeshProjectionWidget(QtWidgets.QWidget):
     def _project_clicked(self):
         self._projected_graphics_available = True
         node_coordinate_field_name = self._ui.comboBoxNodeCoordinateField.currentData().getName()
-        datapoint_coordinate_field_name = self._ui.comboBoxDatapointCoordinateField.currentData().getName()
+        datapoint_field = self._ui.comboBoxDatapointCoordinateField.currentData()
+        datapoint_coordinate_field_name = datapoint_field.getName() if datapoint_field else None
         self._model.project(node_coordinate_field_name, datapoint_coordinate_field_name)
         self._scene.visualise_projected_graphics(node_coordinate_field_name, datapoint_coordinate_field_name)
 


### PR DESCRIPTION
The model has been changed slightly so that it now uses a Zinc `Plane` to handle the plane information. This is in line with these changes made to the plane handlers: [Widgets PR#73](https://github.com/cmlibs-python/cmlibs.widgets/pull/73).

I have also made some changes to the way the data-points-field combo box is used, as I thought it might be worth supporting workflows that only want to project mesh nodes and elements, and do not contain data-points. @hsorby, let me know if you want me to revise any of these changes.